### PR TITLE
Memory leak fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,15 +3041,6 @@
       "integrity": "sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA==",
       "dev": true
     },
-    "@types/inversify": {
-      "version": "2.0.33",
-      "resolved": "https://registry.npmjs.org/@types/inversify/-/inversify-2.0.33.tgz",
-      "integrity": "sha1-B3Da4imaruV4A/dSNeZKmbdPbeA=",
-      "dev": true,
-      "requires": {
-        "inversify": "*"
-      }
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -8590,9 +8581,9 @@
       }
     },
     "inversify": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.1.tgz",
-      "integrity": "sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.5.tgz",
+      "integrity": "sha512-60QsfPz8NAU/GZqXu8hJ+BhNf/C/c+Hp0eDc6XMIJTxBiP36AQyyQKpBkOVTLWBFDQWYVHpbbEuIsHu9dLuJDA==",
       "dev": true
     },
     "ip": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "build": "rimraf lib && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
-    "example": "nuxt example -c nuxt.config.ts"
+    "example": "nuxt example -c nuxt.config.ts",
+    "example-build": "nuxt build example -c nuxt.config.ts",
+    "example-start-debug": "node --inspect node_modules/.bin/nuxt start example"
   },
   "files": [
     "README.md",
@@ -40,13 +42,12 @@
   "devDependencies": {
     "@nuxt/types": "2.14.3",
     "@nuxt/typescript-build": "2.0.2",
-    "@types/inversify": "2.0.33",
     "@types/jest": "26.0.10",
     "@types/lodash": "4.14.165",
     "@types/node": "14.6.0",
     "@vue/test-utils": "1.1.1",
     "babel-core": "6.26.3",
-    "inversify": "5.0.1",
+    "inversify": "5.0.5",
     "jest": "26.4.2",
     "lodash": "4.17.20",
     "nuxt": "2.13.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import { Context } from '@nuxt/types';
 import { resolve } from 'path';
-import { destroyContainer } from './System/Decorators';
 export * from './System/Inject';
 export * from './System/Injectable';
 export * from './System/Container';
@@ -35,13 +33,6 @@ export default function NuxtIocModule(this: IModuleContext, moduleOptions: IModu
   this.addPlugin({
     src: resolve(__dirname, 'serializePlugin.js'),
     options,
-  });
-
-  (this as any).nuxt.hook('render:routeDone', (_: any, __: any, context: Context) => {
-    const container = (context.req as any).__container;
-    if (container) {
-      destroyContainer(container);
-    }
   });
 }
 

--- a/tests/System/ComponentUtil.spec.ts
+++ b/tests/System/ComponentUtil.spec.ts
@@ -378,11 +378,13 @@ describe('[Framework][Vue] ComponentUtil', () => {
     expect(spyOnResult).toBeCalledWith('serverPrefetch');
   });
 
-  xit('should unserialize service on front', () => {
+  it('should unserialize service on front', () => {
+    (process as any).client = true;
     const stateSerializer = container.get(StateSerializer);
     const spyOn = jest.spyOn(stateSerializer, 'unserializeService');
     (target as any).beforeCreate.call(MOCK_INSTANCE);
 
     expect(spyOn).toHaveBeenCalled();
+    (process as any).client = false;
   });
 });


### PR DESCRIPTION
We have found that the application can leak memory while having a heavy request load (e.g. using jmeter / siege).

The problem was that `destroyContainer` was not always fired at the end of the user request, some of the decorators were fired just after it. A solution to it is to put container destruction into event loop so its executed while event loop finishes all jobs previously defined while initializing the Container and IOC dependencies.

Solution proves that memory leak is no more here, tested under very heavy load and always garbage collects to around 30-70mb per instance.