### PR TITLE
fixed container section in installation doc

### DIFF
--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -60,11 +60,17 @@ So, lets create the required Application structure:
 The file `container.ts` must export a new container instance, so its content looks like this:
 
 ```ts
-import { Container } from 'nuxt-ioc';
+import { Container, Events, StateSerializer } from 'nuxt-ioc';
 import MyService from './Domain/MyService';
 
 const container = new Container();
+container.bindInstance(Container, container);
 
+// System dependencies
+container.bind(Events);
+container.bind(StateSerializer);
+
+// Application dependencies
 container.bind(MyService); // here we register our sample service
 
 export default container;


### PR DESCRIPTION
Documentation fix to add missing items in installation section. The first time I used the app it generated an error for me so I thought it was worth adding to the docs.

The example usage also includes these imports.
![Zrzut ekranu z 2024-01-10 22-40-10](https://github.com/mateuszgachowski/nuxt-ioc/assets/16881101/8609c57a-2cbe-4c05-a0f5-cd59119684c8)
